### PR TITLE
UI lessons

### DIFF
--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -31,7 +31,7 @@ export default function ElearningCourseDetailsLessonsDialog({
       sx={{
         width: 1,
         height: 1,
-        minHeight: 1,
+        minHeight: { xs: 1, md: 0.8 },
         aspectRatio: 16 / 9,
       }}
     >

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -83,7 +83,7 @@ export default function ElearningCourseDetailsLessonsDialog({
       sx={{
         p: 1,
         overflowY: 'scroll',
-        width: { xs: 1, md: 0.5 },
+        width: { xs: 1, md: 0.4 },
         height: 1,
       }}
     >
@@ -149,7 +149,21 @@ export default function ElearningCourseDetailsLessonsDialog({
         },
       }}
     >
-      <IconButton onClick={onClose} sx={{ top: 8, left: 8, zIndex: 9, position: 'absolute' }}>
+      <IconButton
+        onClick={onClose}
+        sx={{
+          top: 6,
+          right: 24,
+          zIndex: 9,
+          position: 'absolute',
+          backgroundColor: 'white',
+          opacity: 0.3,
+          '&:hover': {
+            backgroundColor: 'white',
+            opacity: 0.8,
+          },
+        }}
+      >
         <Iconify icon="carbon:close" />
       </IconButton>
 

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -32,6 +32,7 @@ export default function ElearningCourseDetailsLessonsDialog({
         width: 1,
         height: 1,
         minHeight: 1,
+        aspectRatio: 16 / 9,
       }}
     >
       {selectedLesson?.videoPath ? (
@@ -69,6 +70,7 @@ export default function ElearningCourseDetailsLessonsDialog({
         p: 2,
         width: 1,
         height: 1,
+        aspectRatio: 16 / 9,
       }}
     >
       <Typography>{selectedLesson?.description}</Typography>
@@ -137,7 +139,7 @@ export default function ElearningCourseDetailsLessonsDialog({
   return (
     <Dialog
       fullWidth
-      maxWidth="lg"
+      fullScreen
       open={open}
       onClose={onClose}
       PaperProps={{
@@ -145,20 +147,19 @@ export default function ElearningCourseDetailsLessonsDialog({
           overflow: 'hidden',
           borderRadius: 0,
         },
-        className: 'min-h-screen min-w-full aspect-video m-0',
       }}
     >
       <IconButton onClick={onClose} sx={{ top: 8, left: 8, zIndex: 9, position: 'absolute' }}>
         <Iconify icon="carbon:close" />
       </IconButton>
 
-      <Stack direction={{ xs: 'column', md: 'row' }} sx={{ height: 1 }}>
+      <Stack direction={{ xs: 'column-reverse', md: 'row' }} sx={{ height: 1 }}>
+        {renderList}
+
         <Stack className="overflow-y-auto">
           {renderVideo}
           {renderDescription}
         </Stack>
-
-        {renderList}
       </Stack>
     </Dialog>
   );


### PR DESCRIPTION
- Changed the video to the right and lesson content to the left with a 16: 9 ratio.
-  Moved the close icon to the right.
- Adjusted the video height to make the content visible.