### PR TITLE
UI courses 2.0

### DIFF
--- a/src/app/checkout/[id]/page.js
+++ b/src/app/checkout/[id]/page.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+
+import MainLayout from 'src/layouts/main';
+import ElearningCheckoutView from 'src/sections/_elearning/view/elearning-checkout-view';
+
+// ----------------------------------------------------------------------
+
+export const metadata = {
+  title: 'Checkout',
+};
+
+export default function ElearningCoursesPage({ params }) {
+  return (
+    <MainLayout>
+      <ElearningCheckoutView courseId={params.id} />
+    </MainLayout>
+  );
+}
+
+ElearningCoursesPage.propTypes = {
+  params: PropTypes.object,
+};

--- a/src/layouts/main/header.js
+++ b/src/layouts/main/header.js
@@ -77,7 +77,7 @@ export default function Header({ headerOnDark }) {
         <Container
           sx={{ height: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
         >
-          <Box sx={{ lineHeight: 0, position: 'relative' }}>
+          <Box sx={{ lineHeight: 0, position: 'relative', width: '20%' }}>
             <Logo />
 
             {/* <Link href="#">
@@ -101,7 +101,12 @@ export default function Header({ headerOnDark }) {
 
           {mdUp && <NavDesktop data={navConfig} />}
 
-          <Stack spacing={4} direction="row" alignItems="center" justifyContent="flex-end">
+          <Stack
+            spacing={{ xs: 0, md: 4 }}
+            direction="row"
+            alignItems="center"
+            justifyContent="flex-end"
+          >
             {/* <Stack spacing={1} direction="row" alignItems="center">
               <Searchbar />
 
@@ -146,9 +151,9 @@ export default function Header({ headerOnDark }) {
                 )}
               </>
             )}
-          </Stack>
 
-          {!mdUp && <NavMobile data={navConfig} />}
+            {!mdUp && <NavMobile data={navConfig} />}
+          </Stack>
         </Container>
       </Toolbar>
 

--- a/src/sections/_elearning/checkout/elearning-checkout-order-summary.js
+++ b/src/sections/_elearning/checkout/elearning-checkout-order-summary.js
@@ -26,6 +26,7 @@ export default function ElearningCheckoutOrderSummary({
   discount,
   courses,
   loading,
+  isDelete,
 }) {
   return (
     <Stack
@@ -41,7 +42,7 @@ export default function ElearningCheckoutOrderSummary({
       {!!courses?.length && (
         <>
           {courses.map((course) => (
-            <CourseItem key={courses.id} course={course} />
+            <CourseItem key={courses.id} course={course} isDelete={isDelete} />
           ))}
 
           <Divider sx={{ borderStyle: 'dashed' }} />
@@ -99,11 +100,12 @@ ElearningCheckoutOrderSummary.propTypes = {
   subtotal: PropTypes.number,
   taxPercent: PropTypes.number,
   total: PropTypes.number,
+  isDelete: PropTypes.bool,
 };
 
 // ----------------------------------------------------------------------
 
-function CourseItem({ course, ...other }) {
+function CourseItem({ course, isDelete, ...other }) {
   const removeCourseFromCart = useCartStore((state) => state.removeFromCart);
 
   return (
@@ -130,9 +132,11 @@ function CourseItem({ course, ...other }) {
         </Typography>
       </Stack>
 
-      <IconButton onClick={() => removeCourseFromCart(course)}>
-        <Iconify icon="carbon:trash-can" />
-      </IconButton>
+      {isDelete && (
+        <IconButton onClick={() => removeCourseFromCart(course)}>
+          <Iconify icon="carbon:trash-can" />
+        </IconButton>
+      )}
     </Stack>
   );
 }
@@ -143,6 +147,7 @@ CourseItem.propTypes = {
     slug: PropTypes.string,
     price: PropTypes.number,
   }),
+  isDelete: PropTypes.bool,
 };
 
 // ----------------------------------------------------------------------

--- a/src/sections/_elearning/details/elearning-course-details-hero.js
+++ b/src/sections/_elearning/details/elearning-course-details-hero.js
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
-import Button from '@mui/material/Button';
+// import Button from '@mui/material/Button';
 import Avatar from '@mui/material/Avatar';
 import Divider from '@mui/material/Divider';
 import Container from '@mui/material/Container';
@@ -56,11 +56,11 @@ export default function ElearningCourseDetailsHero({ course }) {
 
   const videoPlay = useBoolean();
 
-  const handleSelectedLesson = useCallback((lesson) => {
-    if (lesson.unLocked) {
-      setSelectedLesson(lesson);
-    }
-  }, []);
+  // const handleSelectedLesson = useCallback((lesson) => {
+  //   if (lesson.unLocked) {
+  //     setSelectedLesson(lesson);
+  //   }
+  // }, []);
 
   const handleClose = useCallback(() => {
     setSelectedLesson(null);

--- a/src/sections/_elearning/details/elearning-course-details-hero.js
+++ b/src/sections/_elearning/details/elearning-course-details-hero.js
@@ -185,7 +185,7 @@ export default function ElearningCourseDetailsHero({ course }) {
                       + {teachers.length} teachers
                     </Link>
                   )}
-                  <Stack className="ml-2 md:ml-12">
+                  {/* <Stack className="ml-2 md:ml-12">
                     <Button
                       variant="contained"
                       color="primary"
@@ -193,7 +193,7 @@ export default function ElearningCourseDetailsHero({ course }) {
                     >
                       Start Now
                     </Button>
-                  </Stack>
+                  </Stack> */}
                 </Stack>
 
                 <Divider sx={{ borderStyle: 'dashed' }} />

--- a/src/sections/_elearning/details/elearning-course-details-info.js
+++ b/src/sections/_elearning/details/elearning-course-details-info.js
@@ -2,12 +2,15 @@ import PropTypes from 'prop-types';
 
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
+import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
+import { paths } from 'src/routes/paths';
 import Iconify from 'src/components/iconify';
 import { useCartStore } from 'src/states/cart';
+import { RouterLink } from 'src/routes/components';
 import { fCurrency } from 'src/utils/format-number';
 import { useWishlistStore } from 'src/states/wishlist';
 
@@ -88,9 +91,11 @@ export default function ElearningCourseDetailsInfo({ course }) {
           </Stack>
         </Stack>
 
-        <Button variant="contained" size="large" color="inherit">
-          Enrol Now
-        </Button>
+        <Link component={RouterLink} href={`${paths.eLearning.checkout}/${course.id}`}>
+          <Button variant="contained" size="large" color="inherit" sx={{ width: 1 }}>
+            Enroll Now
+          </Button>
+        </Link>
 
         <Box
           sx={{

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -9,15 +9,16 @@ import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 
 import { _coursePosts } from 'src/_mock';
 import Player from 'src/components/player';
 import Iconify from 'src/components/iconify';
 import Markdown from 'src/components/markdown';
+import { useResponsive } from 'src/hooks/use-responsive';
 
 import PostTags from '../../blog/common/post-tags';
 import PostSocialsShare from '../../blog/common/post-socials-share';
-import { CloseIcon } from 'yet-another-react-lightbox';
 
 // ----------------------------------------------------------------------
 
@@ -34,6 +35,8 @@ export default function ElearningCourseDetailsLessonsDialog({
   onPause,
 }) {
   const { title, description, duration, tags, content } = _coursePosts[0];
+
+  const mdUp = useResponsive('up', 'md');
 
   const renderVideo = (
     <Stack
@@ -116,13 +119,75 @@ export default function ElearningCourseDetailsLessonsDialog({
     </Container>
   );
 
-  const renderList = (
+  const renderListDesktop = (
     <Stack
       spacing={0.5}
       sx={{
         p: 1,
         overflowY: 'scroll',
-        width: { xs: 1, md: 0.5 },
+        width: { xs: 1, md: '44%' },
+        height: 1,
+      }}
+    >
+      {lessons?.map((lesson) => {
+        const selected = selectedLesson?.id === lesson.id;
+
+        const playIcon = selected ? 'carbon:pause-outline' : 'carbon:play';
+
+        return (
+          <ListItemButton
+            key={lesson.id}
+            selected={selected}
+            disabled={!lesson.unLocked}
+            onClick={() => onSelectedLesson(lesson)}
+            sx={{ borderRadius: 1, maxHeight: '6rem' }}
+          >
+            <IconButton>
+              <Iconify
+                width="20px"
+                height="20px"
+                icon={!lesson.unLocked ? 'carbon:locked' : playIcon}
+                sx={{
+                  mr: 2,
+                  ...(selected && {
+                    color: 'primary.main',
+                  }),
+                  ...(!lesson.unLocked && {
+                    color: 'text.disabled',
+                  }),
+                }}
+              />
+            </IconButton>
+
+            <ListItemText
+              primary={lesson.title}
+              secondary={lesson.description}
+              primaryTypographyProps={{
+                typography: 'subtitle1',
+                sx: {
+                  ...(selected && {
+                    color: 'primary.main',
+                  }),
+                },
+              }}
+              secondaryTypographyProps={{
+                noWrap: true,
+                component: 'span',
+              }}
+            />
+          </ListItemButton>
+        );
+      })}
+    </Stack>
+  );
+
+  const renderListMobile = (
+    <Stack
+      spacing={0.5}
+      sx={{
+        p: 1,
+        overflowY: 'scroll',
+        width: 1,
         height: 1,
       }}
     >
@@ -201,7 +266,7 @@ export default function ElearningCourseDetailsLessonsDialog({
       </IconButton>
 
       <Stack direction={{ xs: 'column-reverse', md: 'row' }} sx={{ height: 1 }}>
-        {renderList}
+        {mdUp ? renderListDesktop : renderListMobile}
         {renderLesson}
       </Stack>
     </Dialog>

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -2,13 +2,21 @@ import PropTypes from 'prop-types';
 
 import Stack from '@mui/material/Stack';
 import Dialog from '@mui/material/Dialog';
+import Divider from '@mui/material/Divider';
+import Grid from '@mui/material/Unstable_Grid2';
+import Container from '@mui/material/Container';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
 
+import { _coursePosts } from 'src/_mock';
 import Player from 'src/components/player';
 import Iconify from 'src/components/iconify';
+import Markdown from 'src/components/markdown';
+
+import PostTags from '../../blog/common/post-tags';
+import PostSocialsShare from '../../blog/common/post-socials-share';
 
 // ----------------------------------------------------------------------
 
@@ -24,6 +32,8 @@ export default function ElearningCourseDetailsLessonsDialog({
   onPlay,
   onPause,
 }) {
+  const { title, description, duration, tags, content } = _coursePosts[0];
+
   const renderVideo = (
     <Stack
       alignItems="center"
@@ -31,7 +41,6 @@ export default function ElearningCourseDetailsLessonsDialog({
       sx={{
         width: 1,
         height: 1,
-        minHeight: { xs: 1, md: 0.8 },
         aspectRatio: 16 / 9,
       }}
     >
@@ -63,18 +72,47 @@ export default function ElearningCourseDetailsLessonsDialog({
     </Stack>
   );
 
-  const renderDescription = (
-    <Stack
-      spacing={1}
-      sx={{
-        p: 2,
-        width: 1,
-        height: 1,
-        aspectRatio: 16 / 9,
-      }}
-    >
-      <Typography>{selectedLesson?.description}</Typography>
-    </Stack>
+  const renderLesson = (
+    <Container className="overflow-y-scroll py-14">
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        sx={{ borderRadius: 2, overflow: 'hidden' }}
+      >
+        {renderVideo}
+      </Stack>
+
+      <Grid container spacing={3} justifyContent={{ md: 'center' }}>
+        <Grid xs={12} md={8}>
+          <Stack
+            spacing={3}
+            sx={{
+              pb: 6,
+              textAlign: 'center',
+              pt: { xs: 6, md: 10 },
+            }}
+          >
+            <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+              {duration}
+            </Typography>
+
+            <Typography variant="h2" component="h1">
+              {title}
+            </Typography>
+
+            <Typography variant="h5">{description}</Typography>
+          </Stack>
+
+          <Divider sx={{ mb: 6 }} />
+
+          <Markdown content={content} firstLetter />
+
+          <PostTags tags={tags} />
+
+          <PostSocialsShare />
+        </Grid>
+      </Grid>
+    </Container>
   );
 
   const renderList = (
@@ -83,7 +121,7 @@ export default function ElearningCourseDetailsLessonsDialog({
       sx={{
         p: 1,
         overflowY: 'scroll',
-        width: { xs: 1, md: 0.4 },
+        width: { xs: 1, md: 0.5 },
         height: 1,
       }}
     >
@@ -156,12 +194,6 @@ export default function ElearningCourseDetailsLessonsDialog({
           right: 24,
           zIndex: 9,
           position: 'absolute',
-          backgroundColor: 'white',
-          opacity: 0.3,
-          '&:hover': {
-            backgroundColor: 'white',
-            opacity: 0.8,
-          },
         }}
       >
         <Iconify icon="carbon:close" />
@@ -169,11 +201,7 @@ export default function ElearningCourseDetailsLessonsDialog({
 
       <Stack direction={{ xs: 'column-reverse', md: 'row' }} sx={{ height: 1 }}>
         {renderList}
-
-        <Stack className="overflow-y-auto">
-          {renderVideo}
-          {renderDescription}
-        </Stack>
+        {renderLesson}
       </Stack>
     </Dialog>
   );

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Stack from '@mui/material/Stack';
@@ -37,6 +38,12 @@ export default function ElearningCourseDetailsLessonsDialog({
   const { title, description, duration, tags, content } = _coursePosts[0];
 
   const mdUp = useResponsive('up', 'md');
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const toggleDrawer = (value) => {
+    setDrawerOpen(value);
+  };
 
   const renderVideo = (
     <Stack
@@ -182,62 +189,109 @@ export default function ElearningCourseDetailsLessonsDialog({
   );
 
   const renderListMobile = (
-    <Stack
-      spacing={0.5}
-      sx={{
-        p: 1,
-        overflowY: 'scroll',
-        width: 1,
-        height: 1,
+    <SwipeableDrawer
+      anchor="bottom"
+      open={drawerOpen}
+      onClose={() => toggleDrawer(false)}
+      onOpen={() => toggleDrawer(true)}
+      swipeAreaWidth={56}
+      ModalProps={{
+        keepMounted: true,
+        style: { zIndex: 1300 },
       }}
+      sx={{ '.MuiDrawer-paper': { height: '60%', overflow: 'visible' } }}
     >
-      {lessons?.map((lesson) => {
-        const selected = selectedLesson?.id === lesson.id;
+      <Stack
+        sx={{
+          position: 'absolute',
+          top: -56,
+          borderTopLeftRadius: 8,
+          borderTopRightRadius: 8,
+          visibility: 'visible',
+          right: 0,
+          left: 0,
+        }}
+      >
+        <IconButton
+          sx={{
+            alignSelf: 'center',
+            width: 40,
+            height: 40,
+            borderRadius: 3,
+            top: 8,
+            background: 'white',
+          }}
+          onClick={() => toggleDrawer(false)}
+          className="animate-bounce"
+        >
+          <Iconify
+            icon={drawerOpen ? 'carbon:arrow-down' : 'carbon:arrow-up'}
+            width="25px"
+            height="25px"
+          />
+        </IconButton>
+      </Stack>
+      <Stack
+        spacing={0.5}
+        sx={{
+          p: 1,
+          pt: 2,
+          overflowY: 'scroll',
+          width: 1,
+          height: 1,
+        }}
+      >
+        {lessons?.map((lesson) => {
+          const selected = selectedLesson?.id === lesson.id;
 
-        const playIcon = selected ? 'carbon:pause-outline' : 'carbon:play';
+          const playIcon = selected ? 'carbon:pause-outline' : 'carbon:play';
 
-        return (
-          <ListItemButton
-            key={lesson.id}
-            selected={selected}
-            disabled={!lesson.unLocked}
-            onClick={() => onSelectedLesson(lesson)}
-            sx={{ borderRadius: 1, maxHeight: '6rem' }}
-          >
-            <Iconify
-              width={24}
-              icon={!lesson.unLocked ? 'carbon:locked' : playIcon}
-              sx={{
-                mr: 2,
-                ...(selected && {
-                  color: 'primary.main',
-                }),
-                ...(!lesson.unLocked && {
-                  color: 'text.disabled',
-                }),
-              }}
-            />
+          return (
+            <ListItemButton
+              key={lesson.id}
+              selected={selected}
+              disabled={!lesson.unLocked}
+              onClick={() => onSelectedLesson(lesson)}
+              sx={{ borderRadius: 1, maxHeight: '6rem' }}
+            >
+              <IconButton>
+                <Iconify
+                  width="16px"
+                  height="16px"
+                  icon={!lesson.unLocked ? 'carbon:locked' : playIcon}
+                  sx={{
+                    mr: 2,
+                    ...(selected && {
+                      color: 'primary.main',
+                    }),
+                    ...(!lesson.unLocked && {
+                      color: 'text.disabled',
+                    }),
+                  }}
+                />
+              </IconButton>
 
-            <ListItemText
-              primary={lesson.title}
-              secondary={lesson.description}
-              primaryTypographyProps={{
-                typography: 'subtitle1',
-                sx: {
-                  ...(selected && {
-                    color: 'primary.main',
-                  }),
-                },
-              }}
-              secondaryTypographyProps={{
-                noWrap: true,
-                component: 'span',
-              }}
-            />
-          </ListItemButton>
-        );
-      })}
-    </Stack>
+              <ListItemText
+                primary={lesson.title}
+                secondary={lesson.description}
+                primaryTypographyProps={{
+                  typography: 'subtitle1',
+                  sx: {
+                    ...(selected && {
+                      color: 'primary.main',
+                    }),
+                  },
+                }}
+                secondaryTypographyProps={{
+                  noWrap: true,
+                  component: 'span',
+                }}
+              />
+            </ListItemButton>
+          );
+        })}
+      </Stack>
+    </SwipeableDrawer>
   );
 
   return (
@@ -257,7 +311,7 @@ export default function ElearningCourseDetailsLessonsDialog({
         onClick={onClose}
         sx={{
           top: 6,
-          right: 24,
+          right: { xs: 4, md: 24 },
           zIndex: 9,
           position: 'absolute',
         }}

--- a/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
+++ b/src/sections/_elearning/details/elearning-course-details-lessons-dialog.js
@@ -17,6 +17,7 @@ import Markdown from 'src/components/markdown';
 
 import PostTags from '../../blog/common/post-tags';
 import PostSocialsShare from '../../blog/common/post-socials-share';
+import { CloseIcon } from 'yet-another-react-lightbox';
 
 // ----------------------------------------------------------------------
 
@@ -196,7 +197,7 @@ export default function ElearningCourseDetailsLessonsDialog({
           position: 'absolute',
         }}
       >
-        <Iconify icon="carbon:close" />
+        <Iconify icon="carbon:close" width="25px" height="25px" />
       </IconButton>
 
       <Stack direction={{ xs: 'column-reverse', md: 'row' }} sx={{ height: 1 }}>

--- a/src/sections/_elearning/landing/elearning-landing-featured-courses.js
+++ b/src/sections/_elearning/landing/elearning-landing-featured-courses.js
@@ -97,7 +97,7 @@ export default function ElearningLandingFeaturedCourses({ courses }) {
                   pb: { xs: 10, md: 15 },
                 }}
               >
-                <ElearningCourseItem course={course} vertical />
+                <ElearningCourseItem course={course} vertical id={course.id} />
               </Box>
             ))}
           </Carousel>

--- a/src/sections/_elearning/view/elearning-checkout-view.js
+++ b/src/sections/_elearning/view/elearning-checkout-view.js
@@ -15,6 +15,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 
+import { _courses } from 'src/_mock';
 import { paths } from 'src/routes/paths';
 import Iconify from 'src/components/iconify';
 import { useRouter } from 'src/routes/hooks';
@@ -51,17 +52,18 @@ const PAYMENT_OPTIONS = [
 
 // ----------------------------------------------------------------------
 
-export default function ElearningCheckoutView() {
+export default function ElearningCheckoutView({ courseId }) {
   const loading = useBoolean(true);
 
   const router = useRouter();
 
   const formOpen = useBoolean();
 
-  const _courses = useCartStore((state) => state.cart);
+  const coursesCart = useCartStore((state) => state.cart);
+  const courses = courseId ? _courses.filter((course) => course.id === courseId) : coursesCart;
   const emptyCart = useCartStore((state) => state.emptyCart);
 
-  const cost = _courses.map((course) => course.price).reduce((a, b) => a + b, 0);
+  const cost = courses.map((course) => course.price).reduce((a, b) => a + b, 0);
   const discountPercent = cost && 7;
   const taxPercent = cost && 18;
 
@@ -182,8 +184,9 @@ export default function ElearningCheckoutView() {
                 total={total}
                 subtotal={subTotal}
                 discount={discount}
-                courses={_courses}
+                courses={courses}
                 loading={isSubmitting}
+                isDelete={!courseId}
               />
             </Grid>
           </Grid>
@@ -194,6 +197,10 @@ export default function ElearningCheckoutView() {
     </>
   );
 }
+
+ElearningCheckoutView.propTypes = {
+  courseId: PropTypes.string,
+};
 
 // ----------------------------------------------------------------------
 

--- a/src/sections/_elearning/view/elearning-landing-view.js
+++ b/src/sections/_elearning/view/elearning-landing-view.js
@@ -1,11 +1,11 @@
 'use client';
 
-import { _courses, _coursePosts, _testimonials } from 'src/_mock';
+import { _courses, _testimonials } from 'src/_mock';
 
 import ElearningNewsletter from '../elearning-newsletter';
 import ElearningLandingHero from '../landing/elearning-landing-hero';
 import ElearningTestimonial from '../testimonial/elearning-testimonial';
-import ElearningLatestPosts from '../../blog/elearning/elearning-latest-posts';
+// import ElearningLatestPosts from '../../blog/elearning/elearning-latest-posts';
 import ElearningLandingFeaturedCourses from '../landing/elearning-landing-featured-courses';
 
 // ----------------------------------------------------------------------

--- a/src/sections/_elearning/view/elearning-landing-view.js
+++ b/src/sections/_elearning/view/elearning-landing-view.js
@@ -19,7 +19,7 @@ export default function ElearningLandingView() {
 
       <ElearningTestimonial testimonials={_testimonials} />
 
-      <ElearningLatestPosts posts={_coursePosts.slice(0, 4)} />
+      {/* <ElearningLatestPosts posts={_coursePosts.slice(0, 4)} /> */}
 
       <ElearningNewsletter />
     </>


### PR DESCRIPTION
- Passed the id prop to the course item to open the specific course from home page.
- Removed the latest posts section form the home page.
- Removed start now button from course.
- Changed the ui of the lessons dialog.
- Increased the close icon size in lessons dialog.
- Seprated the desktop view and mobile view for the lessons list.
- Added mui drawer for the lessons in mobile view.
- Redirected the user to the checkout page when they click the Enroll Now button.
- Updated the navbar to make it responsive.